### PR TITLE
fix: resource panel don't collapse

### DIFF
--- a/apps/example-antd5/src/ResourceWidget/ResourceCollapsePanel.tsx
+++ b/apps/example-antd5/src/ResourceWidget/ResourceCollapsePanel.tsx
@@ -29,7 +29,7 @@ export const ResourceCollapsePanel = (
   return (
     <Collapse
       accordion
-      activeKey={expanded ? key : ""}
+      defaultActiveKey={expanded ? key : ""}
       ghost
       //expandIconPosition="end"
       onChange={handleChange}


### PR DESCRIPTION
# Summary of my changes
初始展开使用 `defaultActiveKey` 
maybe close: #184 
# How did you test these changes?
`defaultActiveKey` 由 `antd` 组件管理折叠状态
# Checklist

- [ ] Assigned reviewer(s)
- [ ] Assigned label(s)
- [ ] Linked or mentioned issue(s)
